### PR TITLE
Only Hitting API Increases API Limiter

### DIFF
--- a/app/src/main/java/com/daniellegolinsky/funshine/data/WeatherRepo.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/data/WeatherRepo.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.ResponseBody
 import retrofit2.Response
+import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import javax.inject.Inject
 import javax.inject.Named
@@ -145,11 +146,19 @@ class WeatherRepo @Inject constructor(
         } catch (uhe: UnknownHostException) {
             // Catches the exception from no internet access
             uhe.printStackTrace()
-            Log.e(LOG_INTERNET_CONNECTION_ERROR, "Exception in API Response: ${uhe.message}")
-            // We know this didn't hit the API because it was an unknown host exception, so don't increment
+            Log.e(LOG_INTERNET_CONNECTION_ERROR, "Unknown host exception in API Response: ${uhe.message}")
+            // We know this didn't hit the API
             incrementApiLimiter = false
             null
-        } catch (e: Exception) {
+        } catch (ste: SocketTimeoutException) {
+            // Catches the exception from no internet access
+            ste.printStackTrace()
+            Log.e(LOG_INTERNET_CONNECTION_ERROR, "Socket timeout exception in API Response: ${ste.message}")
+            // We know this didn't hit the API
+            incrementApiLimiter = false
+            null
+        }
+        catch (e: Exception) {
             e.printStackTrace()
             Log.e(LOG_NULL_RESPONSE, "Unknown exception: ${e.message}")
             null

--- a/app/src/main/java/com/daniellegolinsky/funshine/data/WeatherRepo.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/data/WeatherRepo.kt
@@ -1,20 +1,20 @@
 package com.daniellegolinsky.funshine.data
 
+import android.util.Log
 import com.daniellegolinsky.funshine.api.OpenMeteoWeatherService
 import com.daniellegolinsky.funshine.di.ApplicationModule
 import com.daniellegolinsky.funshine.models.Forecast
 import com.daniellegolinsky.funshine.models.ForecastTimestamp
 import com.daniellegolinsky.funshine.models.api.ForecastError
 import com.daniellegolinsky.funshine.models.ResponseOrError
-import com.daniellegolinsky.funshine.models.WeatherCode
 import com.daniellegolinsky.funshine.models.api.WeatherRequest
 import com.daniellegolinsky.funshine.models.api.WeatherResponse
 import com.daniellegolinsky.funshine.models.hoursBetween
-import com.daniellegolinsky.funshine.models.toWeatherCode
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.ResponseBody
 import retrofit2.Response
+import java.net.UnknownHostException
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -26,6 +26,8 @@ class WeatherRepo @Inject constructor(
 
     companion object{
         const val API_REQUEST_ERROR = "API_REQUEST_ERROR"
+        const val LOG_INTERNET_CONNECTION_ERROR = "INTERNET_CONNECTION_ERROR"
+        const val LOG_NULL_RESPONSE = "NULL_API_RESPONSE"
     }
 
     private val weatherMutex = Mutex()
@@ -129,7 +131,8 @@ class WeatherRepo @Inject constructor(
         requestLengthUnit: String,
     ): ResponseOrError<Forecast, ForecastError> {
 
-        apiRequestLimiter.incrementApiCallCounter()
+        // Will increment only if we actually hit the API, set to increment by default
+        var incrementApiLimiter = true
 
         var apiResponse: Response<WeatherResponse>? = try {
             weatherService.getCurrentWeather(
@@ -139,9 +142,28 @@ class WeatherRepo @Inject constructor(
                 speedUnit = requestSpeedUnit,
                 lengthUnit = requestLengthUnit,
             )
+        } catch (uhe: UnknownHostException) {
+            // Catches the exception from no internet access
+            uhe.printStackTrace()
+            Log.e(LOG_INTERNET_CONNECTION_ERROR, "Exception in API Response: ${uhe.message}")
+            // We know this didn't hit the API because it was an unknown host exception, so don't increment
+            incrementApiLimiter = false
+            null
         } catch (e: Exception) {
             e.printStackTrace()
+            Log.e(LOG_NULL_RESPONSE, "Unknown exception: ${e.message}")
             null
+        }
+
+        if (apiResponse == null) {
+            Log.e(LOG_NULL_RESPONSE, "API Response was null")
+        }
+
+        if (incrementApiLimiter) {
+            apiRequestLimiter.incrementApiCallCounter()
+            if (apiResponse == null) {
+                Log.e(LOG_NULL_RESPONSE, "Incremented API, even though it's a null response.")
+            }
         }
 
         return mapWeatherResponseToForecastOrError(

--- a/app/src/main/java/com/daniellegolinsky/funshine/di/ApplicationModule.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/di/ApplicationModule.kt
@@ -56,6 +56,8 @@ object ApplicationModule {
         val httpClient = OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
             .readTimeout(10, TimeUnit.SECONDS)
+            .callTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
 
         val retrofit = Retrofit.Builder()
             .baseUrl("https://api.open-meteo.com/")

--- a/app/src/main/java/com/daniellegolinsky/funshine/di/ApplicationModule.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/di/ApplicationModule.kt
@@ -55,9 +55,6 @@ object ApplicationModule {
         loggingInterceptor.level = HttpLoggingInterceptor.Level.NONE
         val httpClient = OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .callTimeout(10, TimeUnit.SECONDS)
-            .connectTimeout(10, TimeUnit.SECONDS)
 
         val retrofit = Retrofit.Builder()
             .baseUrl("https://api.open-meteo.com/")

--- a/app/src/main/java/com/daniellegolinsky/funshine/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/ui/about/AboutScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.daniellegolinsky.funshine.BuildConfig
 import com.daniellegolinsky.funshine.R
 import com.daniellegolinsky.funshine.ui.ScreenConstants
 import com.daniellegolinsky.funshinetheme.components.FsAppBar
@@ -33,6 +34,7 @@ fun AboutScreen(
     val uriHandler = LocalUriHandler.current
     val funshinePrivacyLink = stringResource(id = R.string.funshine_privacy_link)
     val openMeteoTermsLink = stringResource(id = R.string.open_meteo_terms_link)
+    val version = BuildConfig.VERSION_NAME
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -81,6 +83,8 @@ fun AboutScreen(
                     uriHandler.openUri(openMeteoTermsLink)
                 }
             )
+            Spacer(modifier = Modifier.height(32.dp))
+            FsText(text = stringResource(id = R.string.version) + " $version", textStyle = getBodyFontStyle())
             Spacer(modifier = Modifier.height(96.dp)) // End spacing for foldable outer screens
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="open_meteo_terms_link">https://open-meteo.com/en/terms</string>
     <string name="funshine_privacy">FunShine Privacy</string>
     <string name="funshine_privacy_link">https://daniellegolinsky.com/privacy-policies/</string>
+    <string name="version">Version:</string>
     <string name="option_f">ºF</string>
     <string name="option_c">ºC</string>
     <string name="option_mph">MPH</string>


### PR DESCRIPTION
Basically, you could hit the API limiter with requests that had an exception pointing to the fact that they never hit the API. We only want to limit successful hits on the API anyway. 

This also adds some logging for these issues, as well as a version code on the about screen, in case someone contacts me and needs support, I can walk them through providing the version code and logcat. 

Again, no logs are collected, but if we add anything like Sentry, we'd have to audit logs. 