### PR TITLE
Fixes failure to reset API

### DIFF
--- a/app/src/main/java/com/daniellegolinsky/funshine/data/IApiRequestLimiter.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/data/IApiRequestLimiter.kt
@@ -2,7 +2,6 @@ package com.daniellegolinsky.funshine.data
 
 interface IApiRequestLimiter {
     suspend fun incrementApiCallCounter()
-    suspend fun resetApiCallCounterAndTimestampIfValid()
-    suspend fun canMakeRequest(): Boolean
+    suspend fun requestPermitted(): Boolean
     suspend fun hoursLeft(): Int
 }

--- a/app/src/main/java/com/daniellegolinsky/funshine/data/WeatherRepo.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/data/WeatherRepo.kt
@@ -85,9 +85,8 @@ class WeatherRepo @Inject constructor(
     ): ResponseOrError<Forecast, ForecastError> {
         // Reset the API limiter if necessary
         weatherMutex.withLock {
-            apiRequestLimiter.resetApiCallCounterAndTimestampIfValid()
-            // Only perform API actions if under the daily limit
-            if (apiRequestLimiter.canMakeRequest()) {
+            // Check if request is permitted.
+            if (apiRequestLimiter.requestPermitted()) {
                 // Do the request and cache the response locally
                 repoCachedWeatherResponse = makeApiRequest(
                     requestLatitude = weatherRequest.location.latitude,

--- a/app/src/main/java/com/daniellegolinsky/funshine/models/ForecastTimestamp.kt
+++ b/app/src/main/java/com/daniellegolinsky/funshine/models/ForecastTimestamp.kt
@@ -19,7 +19,7 @@ data class ForecastTimestamp(
         const val HOURS_IN_YEAR: Int = HOURS_IN_DAY * 365
         fun getCurrentTimestamp(): ForecastTimestamp {
             val currentHour = LocalDateTime.now().hour
-            val currentDay = LocalDateTime.now().dayOfMonth
+            val currentDay = LocalDateTime.now().dayOfYear
             val currentYear = LocalDateTime.now().year
             return ForecastTimestamp(year = currentYear, day = currentDay, hour = currentHour)
         }

--- a/app/src/test/java/com/daniellegolinsky/funshine/ApiRequestLimiterTest.kt
+++ b/app/src/test/java/com/daniellegolinsky/funshine/ApiRequestLimiterTest.kt
@@ -17,27 +17,37 @@ class ApiRequestLimiterTest {
     fun shouldBlockNewCalls() = runTest {
         mockDataStore.setApiCallCount(ApiRequestLimiter.MAX_DAILY_REQUESTS)
         mockDataStore.setNewApiTimestamp(ForecastTimestamp.getCurrentTimestamp())
-        assertFalse(apiRequestLimiter.canMakeRequest())
+        assertFalse(apiRequestLimiter.requestPermitted())
     }
 
     @Test
     fun shouldNotBlockNewCalls() = runTest {
         mockDataStore.setApiCallCount(0)
         mockDataStore.setNewApiTimestamp(ForecastTimestamp.getCurrentTimestamp())
-        assert(apiRequestLimiter.canMakeRequest())
+        assert(apiRequestLimiter.requestPermitted())
     }
 
     @Test
     fun atApiLimitButOlderThanOneDay() = runTest {
         val today = ForecastTimestamp.getCurrentTimestamp()
-        val yesterday = today.copy(day = today.day - 1, hour = today.hour - 1)
+        val newYear = if (today.day == 1) {
+            today.year - 1
+        } else {
+            today.year
+        }
+        val newDay = if (today.day == 1) {
+            31
+        } else {
+            today.day - 1
+        }
+        val yesterday = ForecastTimestamp(year = newYear, day = newDay, hour = today.hour - 1)
         mockDataStore.setApiCallCount(ApiRequestLimiter.MAX_DAILY_REQUESTS)
+        mockDataStore.setNewApiTimestamp(today)
+        // If the request comes in today, it should fail
+        assertFalse(apiRequestLimiter.requestPermitted())
         mockDataStore.setNewApiTimestamp(yesterday)
-        // First make sure that, without reset, this fails
-        assertFalse(apiRequestLimiter.canMakeRequest())
         // Reset and test again
-        apiRequestLimiter.resetApiCallCounterAndTimestampIfValid()
-        assert(apiRequestLimiter.canMakeRequest())
+        assert(apiRequestLimiter.requestPermitted())
     }
 
     @Test
@@ -45,9 +55,7 @@ class ApiRequestLimiterTest {
         val today = ForecastTimestamp.getCurrentTimestamp()
         mockDataStore.setApiCallCount(ApiRequestLimiter.MAX_DAILY_REQUESTS)
         mockDataStore.setNewApiTimestamp(today)
-        // Should not be able to reset because timestamp is from today
-        apiRequestLimiter.resetApiCallCounterAndTimestampIfValid()
-        assertFalse(apiRequestLimiter.canMakeRequest())
+        assertFalse(apiRequestLimiter.requestPermitted())
     }
 
     @Test
@@ -55,9 +63,9 @@ class ApiRequestLimiterTest {
         val today = ForecastTimestamp.getCurrentTimestamp()
         mockDataStore.setApiCallCount(ApiRequestLimiter.MAX_DAILY_REQUESTS - 1)
         mockDataStore.setNewApiTimestamp(today)
-        assert(apiRequestLimiter.canMakeRequest())
+        assert(apiRequestLimiter.requestPermitted())
         apiRequestLimiter.incrementApiCallCounter()
-        assertFalse(apiRequestLimiter.canMakeRequest())
+        assertFalse(apiRequestLimiter.requestPermitted())
     }
 
     @Test


### PR DESCRIPTION
Day of month was used instead of day of year. Also forced reset when trying to see if the api could make another request if valid. Tying them together should prevent issues in the future.